### PR TITLE
strg-3925-update-circleci-docker-image-used-in-the-build-pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12.5.0
+      - image: cimg/node:14.21
     working_directory: ~/repo
     environment:
       - TEST_OUTPUT_FILE: test.metrics

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/node:14.21
+      - image: cimg/python:3.12.5-node
     working_directory: ~/repo
     environment:
       - TEST_OUTPUT_FILE: test.metrics


### PR DESCRIPTION
Update circle ci build image